### PR TITLE
Support debug multiple same ARM core 

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -54,6 +54,7 @@ export declare interface GDBBackend {
         data: any
     ): boolean;
     emit(event: 'attachedRequest'): boolean;
+    
 }
 
 export class GDBBackend extends events.EventEmitter {


### PR DESCRIPTION
Currently, we need to support multi-process debugging as each core  ARM (CA55 + CR52) for R-CAR S4 device. 
Since it is not possible to override the export declare interface GDBBackend method in the RenesasGDBBackend.ts class or the GDBTargetDebugSession.ts class. We need to update the code at the GDBBackend.ts class of the cdt-gdb-adapter.