### PR TITLE
Make a delay to GDB server to be terminated

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1551,6 +1551,10 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await this.gdb.sendGDBExit();
+            // Delay 5 ms to wait for GDB server to be terminated completely
+            if(_args.restart){
+                await new Promise((res) => setTimeout(res, 5000));
+            }
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(


### PR DESCRIPTION
When **restart** request is called, the disconnectRequest() and launchRequest() will be called. In the disconnectRequest() will send a '**-gdb-exit**' command to exit GDB server then the launch method will called to start a new GDB server. But LaunchRequest() is not wait for GDB server is terminated completely to run and start a new GDB server. In this case, Emulator is still being held by old GDB server, So cannot start a new GDB server. 
**Solution**: Make a delay to wait for GDB server is terminated completely